### PR TITLE
Fixed issue with .gifv paths.

### DIFF
--- a/framework/js/main.js
+++ b/framework/js/main.js
@@ -46,14 +46,13 @@ function loadImages () {
         /* Only accept pictures from imgur and i.redd, as other websites (such as flickr)
            can have restrictions on which photos can be downloaded. */
 
-        // while(imageUrl.indexOf('imgur') == -1){
-        while(imageUrl.indexOf('i.redd.it') == -1 && imageUrl.indexOf('imgur') == -1){
+        while(imageUrl.indexOf('i.redd.it') == -1 && imageUrl.indexOf('imgur') == -1 || imageUrl.endsWith('.gifv')){
             imageUrl = data['data']['children'][i++]['data']['url'];
         }
 
         /* Specific urls to imgur.com do not always come as link to .jpgs, detect and correct. */
 
-        if(!(imageUrl.endsWith('.jpg')) && imageUrl.indexOf('imgur') != -1){
+        if(!imageUrl.endsWith('.jpg') && imageUrl.indexOf('imgur') != -1){
             imageUrl += '.jpg';
         }
 
@@ -86,7 +85,7 @@ function loadImages () {
         var i = 0;
         var imageUrl = data['data']['children'][i++]['data']['url'];
 
-        while(imageUrl.indexOf('i.redd.it') == -1 && imageUrl.indexOf('imgur') == -1){
+        while(imageUrl.indexOf('i.redd.it') == -1 && imageUrl.indexOf('imgur') == -1 || imageUrl.endsWith('.gifv')){
             imageUrl = data['data']['children'][i++]['data']['url'];
         }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name":"Learn something, See something",
   "short_name": "LSSS",
-  "version":"1.10",
+  "version":"1.11",
   "manifest_version":2,
   "description":"We grow a little every day.",
 


### PR DESCRIPTION
.gifv files are not able to be displayed (although .gif files can be displayed), had not previously encountered this file type. Rectified issue.